### PR TITLE
2 - Condense the parsing process

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ $ npm install dry-parser
     "dir": {
         "assets": "assets",
         "less": "{dir.assets}/less",
-        "bower": "{dir.assets}/bower_components",
+        "bower": "{dir.assets}/bower_components"
     },
     "lib": {
-        "jquery": "{dir.bower}/jquery/jquery.js",
+        "jquery": "{dir.bower}/jquery/jquery.js"
     }
 }
 ```
@@ -50,10 +50,10 @@ config = dry.config;
     "dir": {
         "assets": "assets",
         "less": "assets/less",
-        "bower": "assets/pkgs",
+        "bower": "assets/pkgs"
     },
     "lib": {
-        "jquery": "assets/pkgs/jquery/jquery.js",
+        "jquery": "assets/pkgs/jquery/jquery.js"
     }
 }
 ```

--- a/dry-parser.js
+++ b/dry-parser.js
@@ -1,21 +1,32 @@
 var _ = require('lodash');
-var dryParser = this;
+var dry = this;
 
 /**
  * Contains a group of frequently used regular expressions.
  * @type {Object}
  */
-dryParser.regex = {
+dry.regex = {
 	binding: /{([\w\.-]+)}/g
 };
+
+/**
+ * Parse the object into a usable form.
+ * @param  {object} object The object to parse.
+ * @return {object}        The parsed representation of the object.
+ */
+dry.parse = function (object) {
+	dry.setConfig(object);
+	dry.convert();
+	return dry.config;
+}
 
 /**
  * Sets the configuration object to the designated value.
  * @param {object} object The configuration object.
  * @return {undefined}       Returns undefined.
  */
-dryParser.setConfig = function (object) {
-	dryParser.config = object;
+dry.setConfig = function(object) {
+	dry.config = object;
 };
 
 /**
@@ -25,50 +36,50 @@ dryParser.setConfig = function (object) {
  * @param  {array} key       The key path to the layer.
  * @return {undefined}       Returns undefined.
  */
-dryParser.convert = function (object, parentKey, key) {
+dry.convert = function(object, parentKey, key) {
 	/* Concatenate Key to the FullKey if it isn't null. */
 	var fullKey = key ? key : [];
 
 	/* Set layer to the object if its set, otherwise set it to the config. */
-	var layer = object ? object : dryParser.config;
+	var layer = object ? object : dry.config;
 
 	/* Loop through each key. */
-	_.forEach(layer, function (subLayer, subKey) {
+	_.forEach(layer, function(subLayer, subKey) {
 		/* If there's another layer, then recursively call convert. */
 		if (_.isObject(subLayer) || _.isArray(subLayer)) {
-			dryParser.convert(subLayer, fullKey, fullKey.concat(subKey));
+			dry.convert(subLayer, fullKey, fullKey.concat(subKey));
 			/* Otherwise Parse the layer into its final form. */
 		} else if (_.isString(subLayer)) {
 			// Does stuff
-			_.set(dryParser.config, fullKey.concat(subKey), dryParser.parse(subLayer));
+			_.set(dry.config, fullKey.concat(subKey), dry.replace(subLayer));
 		}
 	});
 };
 
 /**
- * Parse the object into a usable value.
+ * Replace the object's bindings with a usable value.
  * @param  {object} value   The object to parse.
  * @return {string}         The parsed value of the object.
  */
-dryParser.parse = function (value) {
+dry.replace = function(value) {
 	var result = value;
 
 	// Replace each binding occurance with its real value.
-	result = result.replace(dryParser.regex.binding, function (match, g1) {
+	result = result.replace(dry.regex.binding, function(match, g1) {
 		// Get the binding's value.
-		var groupValue = _.get(dryParser.config, g1);
+		var groupValue = _.get(dry.config, g1);
 		// If the binding's value is a binding itself.
-		if (_.isString(groupValue) && groupValue.match(dryParser.regex.binding)) {
+		if (_.isString(groupValue) && groupValue.match(dry.regex.binding)) {
 			// Then set the binding's value to its parsed value.
-			_.set(dryParser.config, g1, dryParser.parse(groupValue));
+			_.set(dry.config, g1, dry.replace(groupValue));
 		}
 
 		// Replace the binding with a real value.
-		return _.get(dryParser.config, g1);
+		return _.get(dry.config, g1);
 	});
 
 	// Return the parsed value.
 	return result;
 };
 
-module.exports = dryParser;
+module.exports = dry;


### PR DESCRIPTION
* Fixed README.
* Renamed `parse` to `replace`.
* Added parse function to encompass boilerplate functionality.

This closes #1.