### PR TITLE
29 - Only notify Slack of successful builds on change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ deploy:
 notifications:
   slack:
     secure: ENKTdT08GhdFVnwUYfNp/S9/vdLjSettDlYKBNW1R4loPu8Z55n/fpQGvvvgm+G+aZrcEZb+pK9+ZmeLPm4dU1aCYILqAKHY90940XzyM7Xx5N7xnPl2LDwWhbXO8o5vYN0CJZksv3JBN8waUjNgpGKMX47kmSv9/uqec+1oKjExQCuIjpBm3DrGufh3pxCHc3bCacBba/hlnVMI9MWsdv7/UxExnKfOB5Z1nR67sJoRosBUo+UhZJZMcprcBk7XE+3py9xkW6LrbR2a60MguvVQTdTOEVX904e0ccttAzOZiYqFH/qaQ5iqKOuOUojNqHV7wHgm/Lw5a6mTSSEucYdyWdO6VYrn2LnWB0VKQHyqg07MzaVp85o49dR77+VgV3MEhqVHkLtTGr8tC1UPwSzUwurmu8l26TTiwfPCq0fBDc51q+kTVb2tJ48obUuXTmPkU+QqiG1m/1CAPLYOl8GwDPrWq9nNkQ12nDvfk7iumBBAsNc4+U/EZ9U2zzrQ30j9XsI1ukFinH5U8XeJSmKZae0+ddT+mTdM2X5M9O6QEqDg6N6/k/PvizkafhdxzwD1Wn89syRx7mrF84kLfbdQPBXaCEQ+/Sz1XL5tvUFjinJsEnWGQ08YZ7evWp0nOlisyGrAheo1PiAYvAxvMid1TpEjvC7VHOdJxHXybeI=
+    on_success: change  # options: [always|never|change] default: always
   email: false
 addons:
   code_climate:


### PR DESCRIPTION
* Travis CI will only notify Slack of successful builds, upon changing state.

This closes #29.