### PR TITLE
31 - Make Travis CI cache Node Modules Directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ node_js:
 - node
 - stable
 - iojs
+cache:
+  directories:
+    - node_modules
 deploy:
   provider: npm
   email: admin@arxstudios.net


### PR DESCRIPTION
* Travis CI should cache the node_modules directory.

This closes #31.