### PR TITLE
37 - Remove unnecessary NodeJS Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-- node
 - stable
 - iojs
 cache:


### PR DESCRIPTION
* Removed "node" from build versions

This closes #37.