### PR TITLE
41 - "Dead" bindings should throw a warning to the console

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -111,7 +111,7 @@
 		"wrap-regex": 2,
 
 		"no-sparse-arrays": 1,
-		"no-console": 1,
+		"no-console": 0,
 		"no-alert": 1,
 		"no-constant-condition": 1,
 		"no-unused-vars": 1,

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ dry.parse = function (object, baseObject) {
                 return parsedValue;
             }
 
+            console.warn('The following key doesn\'t map to any values; ', g1);
             return match;
         });
     }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "devDependencies": {
     "chai": "^3.3.0",
     "eslint": "^1.6.0",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "sinon": "^1.17.1"
   },
   "scripts": {
     "test": "mocha"

--- a/test/dryParserSpec.js
+++ b/test/dryParserSpec.js
@@ -1,11 +1,17 @@
 var expect = require('chai').expect;
+var sinon = require('sinon');
 var dry = require('../index');
 
 describe('dryParser', function () {
+    var sandbox;
     var config;
     var object;
 
     beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+        sandbox.stub(console, 'warn');
+        sandbox.stub(console, 'error');
+
         config = {
             'dir': {
                 'assets': 'assets',
@@ -20,6 +26,10 @@ describe('dryParser', function () {
         object = {
             'jquery': '{dir.bower}/jquery/jquery.js'
         };
+    });
+
+    afterEach(function () {
+        sandbox.restore();
     });
 
     describe('#parse()', function () {
@@ -44,6 +54,14 @@ describe('dryParser', function () {
             expect(results).to.deep.equal({
                 'jquery': 'assets/bower_components/jquery/jquery.js'
             });
+        });
+
+        it('should log a warning when passed an invalid config', function () {
+            config.dir.less = '{dir.invalidKey}/less';
+
+            dry.parse(config);
+
+            sinon.assert.calledOnce(console.warn);
         });
 
         it('should retain booleans and integers', function () {


### PR DESCRIPTION
* A warning is now thrown to inform the user of a "dead" binding
* Added unit test for "dead" bindings

This closes #41 